### PR TITLE
extract serializer component

### DIFF
--- a/vcr-sharp-tests/Cassette.cs
+++ b/vcr-sharp-tests/Cassette.cs
@@ -82,6 +82,12 @@ namespace VcrSharp.Tests
             };
 
             var text = JsonConvert.SerializeObject(json);
+            var directory = Path.GetDirectoryName(cassettePath);
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
             return File.WriteAllTextAsync(cassettePath, text);
         }
     }

--- a/vcr-sharp-tests/Serializer.cs
+++ b/vcr-sharp-tests/Serializer.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VcrSharp.Tests
+{
+    public class Serializer
+    {
+        internal static async Task<CachedRequest> Serialize(HttpRequestMessage request)
+        {
+            return new CachedRequest
+            {
+                Headers = request.Headers.ToDictionary(h => h.Key, h => h.Value.ToArray()),
+                Method = request.Method.Method,
+                Uri = request.RequestUri,
+                Body = await ParseContent(request.Content)
+            };
+        }
+
+        internal static HttpRequestMessage Deserialize(CachedRequest cachedRequest)
+        {
+            var request = new HttpRequestMessage();
+            request.Method = new HttpMethod(cachedRequest.Method);
+            request.RequestUri = cachedRequest.Uri;
+            foreach (var kvp in cachedRequest.Headers)
+            {
+                if (IsValidHeader(kvp.Key))
+                {
+                    request.Headers.Add(kvp.Key, kvp.Value);
+                }
+            }
+
+            request.Content = SetContent(cachedRequest.Body, "");
+            return request;
+        }
+
+        internal static async Task<CachedResponse> Serialize(HttpResponseMessage freshResponse)
+        {
+            var responseHeaders = freshResponse.Headers.ToDictionary(h => h.Key, h => h.Value.ToArray());
+            foreach (var kvp in freshResponse.Content.Headers)
+            {
+                responseHeaders.Add(kvp.Key, kvp.Value.ToArray());
+            }
+
+            return new CachedResponse
+            {
+                Headers = responseHeaders,
+                Status = new Status
+                {
+                    Code = (int)freshResponse.StatusCode,
+                    Message = freshResponse.StatusCode.ToString()
+                },
+                Body = await ParseContent(freshResponse.Content)
+            };
+        }
+
+        internal static HttpResponseMessage Deserialize(CachedResponse cachedResponse)
+        {
+            var statusCode = (System.Net.HttpStatusCode)cachedResponse.Status.Code;
+            var response = new HttpResponseMessage(statusCode);
+            foreach (var kvp in cachedResponse.Headers)
+            {
+                if (IsValidHeader(kvp.Key))
+                {
+                    response.Headers.Add(kvp.Key, kvp.Value);
+                }
+            }
+
+            if (cachedResponse.Headers.TryGetValue("Content-Type", out var values))
+            {
+                // TODO: we have encoding information here, we should use that instead of assuming UTF-8
+                var value = values.ElementAt(0);
+                var array = value.Split(';');
+                var rawText = array[0];
+                response.Content = SetContent(cachedResponse.Body, rawText);
+            }
+            return response;
+        }
+
+        static async Task<Body> ParseContent(HttpContent content)
+        {
+            if (content == null)
+            {
+                return new Body
+                {
+                    Encoding = "",
+                    Base64_string = ""
+                };
+            }
+
+            var text = await content.ReadAsStringAsync();
+            var bytes = Encoding.UTF8.GetBytes(text);
+            return new Body
+            {
+                Base64_string = Convert.ToBase64String(bytes),
+                Encoding = "UTF8-8BIT"
+            };
+        }
+
+        static HttpContent SetContent(Body body, string mediaType)
+        {
+            if (body.Encoding == "ASCII-8BIT")
+            {
+                var text = body.Base64_string;
+                var textWithoutNewLines = text.Replace("\n", "");
+                var decodedBytes = Convert.FromBase64String(textWithoutNewLines);
+                var output = Encoding.UTF8.GetString(decodedBytes);
+                return new StringContent(output);
+            }
+
+            if (body.Encoding == "UTF8-8BIT")
+            {
+                var text = body.Base64_string;
+                var decodedBytes = Convert.FromBase64String(text);
+                var output = Encoding.UTF8.GetString(decodedBytes);
+                return new StringContent(output, Encoding.UTF8, mediaType);
+            }
+
+            return null;
+        }
+
+        static bool IsValidHeader(string header)
+        {
+            if (header == "Content-Length"
+                || header == "Last-Modified"
+                || header == "Expires"
+                || header == "Content-Type")
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/vcr-sharp-tests/SerializerTests.cs
+++ b/vcr-sharp-tests/SerializerTests.cs
@@ -1,0 +1,88 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using VcrSharp.Tests;
+using Xunit;
+
+public class SerializerTests
+{
+    public class Get
+    {
+        [Fact]
+        public async Task RountTripRequest()
+        {
+            var client = new HttpClient();
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://api.github.com/meta");
+            request.Headers.UserAgent.ParseAdd("vcr-test");
+            var response = await client.SendAsync(request);
+
+            var serializedRequest = await Serializer.Serialize(request);
+            var deserializedRequest = Serializer.Deserialize(serializedRequest);
+
+            Assert.Equal(request.Version, deserializedRequest.Version);
+            Assert.Equal(request.Method, deserializedRequest.Method);
+            Assert.Equal(request.Content, deserializedRequest.Content);
+        }
+
+        [Fact]
+        public async Task RountTripResponse()
+        {
+            var client = new HttpClient();
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://api.github.com/meta");
+            request.Headers.UserAgent.ParseAdd("vcr-test");
+            var response = await client.SendAsync(request);
+
+            var serializedResponse = await Serializer.Serialize(response);
+            var deserializedResponse = Serializer.Deserialize(serializedResponse);
+
+            Assert.Equal(deserializedResponse.Version, response.Version);
+            Assert.Equal(deserializedResponse.StatusCode, response.StatusCode);
+            Assert.Equal(deserializedResponse.Content.Headers.ContentType, response.Content.Headers.ContentType);
+
+            var actualText = await deserializedResponse.Content.ReadAsStringAsync();
+            var expectedText = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(actualText, expectedText);
+        }
+    }
+
+    public class Post
+    {
+        [Fact]
+        public async Task RountTripRequest()
+        {
+            var client = new HttpClient();
+            var request = new HttpRequestMessage(HttpMethod.Post, "https://api.github.com/user/repos");
+            request.Headers.UserAgent.ParseAdd("vcr-test");
+            var response = await client.SendAsync(request);
+
+            var serializedRequest = await Serializer.Serialize(request);
+            var deserializedRequest = Serializer.Deserialize(serializedRequest);
+
+            Assert.Equal(request.Version, deserializedRequest.Version);
+            Assert.Equal(request.Method, deserializedRequest.Method);
+            Assert.Equal(request.Content, deserializedRequest.Content);
+        }
+
+        [Fact]
+        public async Task RountTripResponse()
+        {
+            var client = new HttpClient();
+            var request = new HttpRequestMessage(HttpMethod.Post, "https://api.github.com/user/repos");
+            request.Headers.UserAgent.ParseAdd("vcr-test");
+            var response = await client.SendAsync(request);
+
+            var serializedResponse = await Serializer.Serialize(response);
+            var deserializedResponse = Serializer.Deserialize(serializedResponse);
+
+            Assert.Equal(response.Version, deserializedResponse.Version);
+            Assert.Equal(response.StatusCode, deserializedResponse.StatusCode);
+            Assert.Equal(response.Content.Headers.ContentType, deserializedResponse.Content.Headers.ContentType);
+
+            var actualText = await deserializedResponse.Content.ReadAsStringAsync();
+            var expectedText = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(actualText, expectedText);
+        }
+    }
+}
+


### PR DESCRIPTION
Still wrapping my head around how best to map between the on-disk representation of request/response pairs and the `System.Net.Http` namespace, but this gets me further with testing some Octokit integration tests.