### PR TITLE
revert to classic File.WriteAllText

### DIFF
--- a/vcr-sharp-tests/Cassette.cs
+++ b/vcr-sharp-tests/Cassette.cs
@@ -88,7 +88,8 @@ namespace VcrSharp.Tests
                 Directory.CreateDirectory(directory);
             }
 
-            return File.WriteAllTextAsync(cassettePath, text);
+            File.WriteAllText(cassettePath, text);
+            return Task.CompletedTask;
         }
     }
 


### PR DESCRIPTION
Haven't really figured out what platforms I want to target initially, so let's just use the classic API for now.