### PR TITLE
relax parsing of environment variables

### DIFF
--- a/vcr-sharp-tests/ReplayingHandler.cs
+++ b/vcr-sharp-tests/ReplayingHandler.cs
@@ -35,23 +35,42 @@ namespace VcrSharp.Tests
 
         }
 
+        static VCRMode Parse(string mode)
+        {
+            if (string.IsNullOrWhiteSpace(mode))
+            {
+                return VCRMode.Playback;
+            }
+
+            var text = mode.Trim();
+            if (text.Equals("playback", StringComparison.OrdinalIgnoreCase))
+            {
+                return VCRMode.Playback;
+            }
+
+            if (text.Equals("cache", StringComparison.OrdinalIgnoreCase))
+            {
+                return VCRMode.Cache;
+            }
+
+            if (text.Equals("record", StringComparison.OrdinalIgnoreCase))
+            {
+                return VCRMode.Record;
+            }
+
+            return VCRMode.Playback;
+        }
+
+        VCRMode? _vcrMode;
         VCRMode CurrentVCRMode
         {
             get
             {
-                var mode = Environment.GetEnvironmentVariable("VCR_MODE");
-
-                if (string.IsNullOrWhiteSpace(mode))
+                if (!_vcrMode.HasValue)
                 {
-                    return VCRMode.Playback;
+                    _vcrMode = Parse(Environment.GetEnvironmentVariable("VCR_MODE"));
                 }
-
-                if (Enum.TryParse(mode, out VCRMode result))
-                {
-                    return result;
-                }
-
-                return VCRMode.Playback;
+                return _vcrMode.Value;
             }
         }
 

--- a/vcr-sharp-tests/ScratchPad.cs
+++ b/vcr-sharp-tests/ScratchPad.cs
@@ -39,7 +39,7 @@ namespace VcrSharp.Tests
         [Fact]
         public async Task WritesAndFlushesAResponseToDisk()
         {
-            Environment.SetEnvironmentVariable("VCR_MODE", "Record");
+            Environment.SetEnvironmentVariable("VCR_MODE", "record");
             var session = "create-local-file";
 
             using (var httpClient = HttpClientFactory.WithCassette(session))
@@ -55,7 +55,7 @@ namespace VcrSharp.Tests
         [Fact]
         public async Task ReplacesExistingRequest()
         {
-            Environment.SetEnvironmentVariable("VCR_MODE", "Cache");
+            Environment.SetEnvironmentVariable("VCR_MODE", "cache");
             var session = "overwrite-request";
 
             var cassette = await ReadCassetteFile(session);


### PR DESCRIPTION
You should be able to all-caps, or all-lower-case the environment variables for `VCR_MODE` - unfortunately enum parsing needs it to match case-wise, so let's bash strings together like our ancestors did.